### PR TITLE
Use entrypoint instead of CMD and make run the server with nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,10 @@ WORKDIR /app
 
 COPY --from=builder /app/bin/server ./bin/server
 
+COPY entrypoint.sh ./
+
+RUN chmod +x ./entrypoint.sh
+
 STOPSIGNAL SIGQUIT
 
-CMD ./bin/server \
-    --port 1323 \
-    --type local \
-    --upload-auth false \
-    --download-auth false \
-    --allowed-list image/png,image/jpeg,image/jpg,image/gif,image/webp \
-    --max-file-size 10
+ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.21 AS builder
 
+RUN useradd -u 1001 -m nonroot
+
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -14,6 +16,8 @@ FROM golang:1.21-alpine AS runner
 
 WORKDIR /app
 
+COPY --from=builder /etc/passwd /etc/passwd
+
 COPY --from=builder /app/bin/server ./bin/server
 
 COPY entrypoint.sh ./
@@ -21,5 +25,7 @@ COPY entrypoint.sh ./
 RUN chmod +x ./entrypoint.sh
 
 STOPSIGNAL SIGQUIT
+
+USER 1001
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '4'
+
+services:
+  file-server:
+    build: .
+    ports: 
+      - "1323:8080"
+    volumes:
+      - ./docker_volumes/files:/app/files
+    environment:
+      - PORT=8080

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+./bin/server \
+    --port=${PORT:-1323} \
+    --type=${TYPE:-local} \
+    --upload-auth=${UPLOAD_AUTH:-false} \
+    --download-auth=${DOWNLOAD_AUTH:-false} \
+    --allowed-list=${ALLOWED_LIST:-image/png,image/jpeg,image/jpg,image/gif,image/webp} \
+    --max-file-size=${MAX_FILE_SIZE:-10}


### PR DESCRIPTION
Also env can now be used to set the runtime config. The docker-compose is an example!